### PR TITLE
2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## 🌟 2.0.0
+
+### ⚠️ Warning: Support for version `<2.0.0` has been dropped. The SoundCloud API's way of identifying resources has changed. Please make sure you update to version `2.0.0`. 
+
+See [SoundCloud developer blog post](https://developers.soundcloud.com/blog/urn-num-to-string). 
+
+### ✨ Features
+- New **Swiftier** ™️  API
+    - Remove all `get-` prefixes
+    - Rename myUser ➡️ currentUser    
+- Update resource property "id" ➡️ "urn" to match SoundCloud public API
+    - These are now **String**
+- Add support for [/resolve](https://developers.soundcloud.com/docs/api/explorer/open-api#/miscellaneous/get_resolve)
+
+### 📋 API updates 
+- Auth
+    - login() → authenticate()
+    - logout() → signOut()
+    - authenticatedHeader (async property) → authorizationHeader
+- Me / Social
+    - getMyUser() → currentUser()
+    - getUsersImFollowing() → usersIFollow()
+    - getMyLikedTracks() → likedTracks()
+    - getMyFollowingsRecentlyPosted() → followingFeed()
+- Playlists
+    - getMyPlaylistsWithoutTracks() → playlists()
+    - getMyLikedPlaylistsWithoutTracks() → likedPlaylists()
+    - getTracksForPlaylist(_:) → tracks(inPlaylist:)
+- Users & Tracks
+    - getTracksForUser(_:_:) → tracks(forUser:limit:)
+    - getLikedTracksForUser(_:_:) → likedTracks(forUser:limit:)
+    - getRelatedTracks(_:_:) → relatedTracks(to:limit:)
+- Search
+    - searchTracks(_: _:) → searchTracks(matching:limit:)
+    - searchPlaylists(_: _:) → searchPlaylists(matching:limit:)
+    - searchUsers(_: _:) → searchUsers(matching:limit:)
+- Paging & Stream Info
+    - pageOfItems(for:) → nextPage(from:)
+    - getStreamInfoForTrack(with:) → streamInfo(for:)
+- Actions
+    - likeTrack(_:) → like(_ track: Track)
+    - unlikeTrack(_:) → unlike(_ track: Track)
+    - likePlaylist(_:) → like(_ playlist: Playlist)
+    - unlikePlaylist(_:) → unlike(_ playlist: Playlist)
+    - followUser(_:) → follow(_ user: User)
+    - unfollowUser(_:) → unfollow(_ user: User)
+
+
 ## 1.2.0
 
 ### ✨ Features

--- a/Package.swift
+++ b/Package.swift
@@ -6,27 +6,37 @@ import PackageDescription
 let package = Package(
     name: "SoundCloud",
     defaultLocalization: "en",
-    platforms: [.iOS(.v15), .watchOS(.v9), .macOS(.v14)],
+    platforms: [
+        .iOS(.v15),
+        .watchOS(.v9),
+        .macOS(.v14)
+    ],
     products: [
         .library(
             name: "SoundCloud",
             type: .static,
-            targets: ["SoundCloud"]),
+            targets: ["SoundCloud"]
+        ),
     ],
     dependencies: [
-        .package(url: "https://github.com/evgenyneu/keychain-swift", from: "20.0.0"),
-        .package(url: "https://github.com/superturboryan/Consolable/" , exact: "1.0.0")
+        .package(
+            url: "https://github.com/evgenyneu/keychain-swift",
+            from: "20.0.0"
+        ),
     ],
     targets: [
         .target(
             name: "SoundCloud",
             dependencies: [
-                .product(name: "KeychainSwift", package: "keychain-swift"),
-                .product(name: "Consolable", package: "Consolable"),
+                .product(
+                    name: "KeychainSwift",
+                    package: "keychain-swift"
+                ),
             ]
         ),
         .testTarget(
             name: "SoundCloudTests",
-            dependencies: ["SoundCloud"]),
+            dependencies: ["SoundCloud"]
+        ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -14,12 +14,17 @@ let package = Package(
             targets: ["SoundCloud"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/evgenyneu/keychain-swift", from: "20.0.0")
+        .package(url: "https://github.com/evgenyneu/keychain-swift", from: "20.0.0"),
+        .package(url: "https://github.com/superturboryan/Consolable/" , exact: "1.0.0")
     ],
     targets: [
         .target(
             name: "SoundCloud",
-            dependencies: [.product(name: "KeychainSwift", package: "keychain-swift")]),
+            dependencies: [
+                .product(name: "KeychainSwift", package: "keychain-swift"),
+                .product(name: "Consolable", package: "Consolable"),
+            ]
+        ),
         .testTarget(
             name: "SoundCloudTests",
             dependencies: ["SoundCloud"]),

--- a/README.md
+++ b/README.md
@@ -1,61 +1,90 @@
+# SoundCloud (Swift)
 
-![SoundCloud package banner light](https://github.com/user-attachments/assets/1f7b6a8a-3163-4dec-8e6b-8f1fba9d792c#gh-light-mode-only)    
-![SoundCloud package banner dark](https://github.com/user-attachments/assets/cd84d1db-596c-41a7-8823-047dd08b3f2b#gh-dark-mode-only)       
-[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fsuperturboryan%2FSoundCloud-Swift%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/superturboryan/SoundCloud-Swift) [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fsuperturboryan%2FSoundCloud-Swift%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/superturboryan/SoundCloud-Swift)
+![SoundCloud package banner light](https://github.com/user-attachments/assets/1f7b6a8a-3163-4dec-8e6b-8f1fba9d792c#gh-light-mode-only)
+![SoundCloud package banner dark](https://github.com/user-attachments/assets/cd84d1db-596c-41a7-8823-047dd08b3f2b#gh-dark-mode-only)
 
-**`SoundCloud`** is a Swift Package that implements the [SoundCloud Public API Specification (v1.0.0) ](https://developers.soundcloud.com/docs/api/explorer/open-api). 
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fsuperturboryan%2FSoundCloud-Swift%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/superturboryan/SoundCloud-Swift)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fsuperturboryan%2FSoundCloud-Swift%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/superturboryan/SoundCloud-Swift)
 
-It handles the logic for authenticating with a SoundCloud account using the OAuth 2.1 standard, **including PKCE**, and provides an API for streaming audio and accessing track, artist, and playlist data from SoundCloud.
+A lightweight Swift package for working with the public SoundCloud API. It handles OAuth 2.1 and gives you convenient async/await APIs to access track, artist, and playlist data, as well as playable stream URLs.
+
+> [!IMPORTANT]
+> **Breaking change (v2.0.0):** SoundCloud migrated resource identifiers from numeric IDs to **string URNs**. Versions `< 2.0.0` of this package are not compatible with this change. Please update to `2.x` and audit any code that assumes numeric IDs. See [release PR](https://github.com/superturboryan/SoundCloud-Swift/pull/14) for more info.
+
+## Features
+- OAuth 2.1 authentication flow with **PKCE**
+- Simple async/await interface
+- Strongly-typed models for common SoundCloud entities
+- Small surface area; focused on the essentials
+- Works great in iOS/watchOS/macOS projects via Swift Package Manager
 
 ## Installation
-`SoundCloud` is available via the Swift Package Manager. Copy the repo link into the search bar:
+`SoundCloud` is available via the [Swift Package Manager](https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/).   
+
+Add this URL in **Xcode → Package Dependencies** (or to your `Package.swift`):
+
 ```
 https://github.com/superturboryan/SoundCloud-Swift/
 ```
-![Screenshot 2025-05-18 at 10 25 05](https://github.com/user-attachments/assets/d074206a-2222-478a-a920-80296383326e)
 
 ## Setup
-[Define a custom URL scheme for your app](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app), you will need to provide a redirect URI using the scheme so that the OAuth web page knows how to open your app when it receives the tokens callback:
+1. **Register your app** on SoundCloud to obtain a client identifier and configure redirect URIs.
+2. **Define a custom URL scheme** in your app so the OAuth callback can return control to your app.
 
-![Screenshot 2025-05-18 at 10 22 49](https://github.com/user-attachments/assets/bf6a19a1-e7b2-40be-87d1-98a447a73071)  
+- Apple docs: [Defining a custom URL scheme](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app)
+- SoundCloud app management: [soundcloud.com/you/apps](https://soundcloud.com/you/apps)
 
+> [!CAUTION]
+> The redirect URI you use **when registering your app with SoundCloud** must match one of the redirect URIs configured for your SoundCloud app.
 
-The redirect URI used when creating the `SoundCloud` instance must also be paired with the client ID and client secret for your [SoundCloud registered app](https://soundcloud.com/you/apps).
-
-## Usage
-To login using a SoundCloud account:
+## Quick Start
+Authenticate with a SoundCloud account:
 
 ```swift
 import SoundCloud
 
-let config = SoundCloudConfig(clientId: ...)
-@StateObject var sc = SoundCloud(config)  
-  
-...  
+let config = SoundCloud.Config(clientId: /* your client id */)
+@StateObject var sc = SoundCloud(config)
 
-    
-do {
-    try await sc.login()
-} catch {
-    // Handle login error
+// ... later, e.g. from a button tap
+Task {
+    do {
+        try await sc.authenticate()
+    } catch {
+        // Handle login error
+        print(error)
+    }
 }
-
 ```
 
-To get the liked tracks for the authenticated user:
+## Usage Examples
+Get the authenticated user's liked tracks:
 
 ```swift
-let likedTracks = try await sc.getMyLikedTracks()
+let likedTracks = try await sc.likedTracks()
 ```
 
-## Example apps
-This package is used by the third-party SoundCloud watchOS app **WatchCloud**, check it out on the [App Store](https://apps.apple.com/us/app/watchcloud/id6466678799) 📲
-
+> Looking for other endpoints? Check the sources for additional convenience APIs and models.
 
 ## Requirements
-SoundCloud requires apps to be registered in order to access their public API. 
-See [terms of use](https://developers.soundcloud.com/docs/api/terms-of-use).  
+Access to the SoundCloud Public API requires a registered app and compliance with their terms:
+- SoundCloud Public API specification: <https://developers.soundcloud.com/docs/api/explorer/open-api>
+- API Terms of Use: <https://developers.soundcloud.com/docs/api/terms-of-use>
 
-<br/>  
+## Migration Notes
+If you're upgrading from `< 2.0.0`, note the switch from numeric IDs to string **URNs** introduced by SoundCloud. Expect types touching `id` fields to change to `String`. Review any code paths that parse or store numeric IDs and update persistence accordingly. See: <https://developers.soundcloud.com/blog/urn-num-to-string>.
+
+## Example Apps
+
+[<img alt="WatchCloud" src="https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/fc/b3/8f/fcb38fc0-fbae-8f7a-0b70-9f1bfbbd719f/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/246x0w.webp" width=60/>](https://apps.apple.com/us/app/watchcloud/id6466678799) 
+
+This package powers the third‑party SoundCloud watchOS app **WatchCloud** — available on the [App Store](https://apps.apple.com/us/app/watchcloud/id6466678799) 📲
+
+If you use this package in your app, let me know and I'll give you a shout‑out! 👋
+
+## Contributing
+Issues and PRs welcome! If you have ideas for additional endpoints or helpers, open an issue to discuss.
+
+---
 
 Banner icon made with [**Strata**](https://apps.apple.com/us/app/strata-icon-generator/id6742242942) 🧡

--- a/Sources/SoundCloud/Assets.xcassets/sc_orange_light.colorset/Contents.json
+++ b/Sources/SoundCloud/Assets.xcassets/sc_orange_light.colorset/Contents.json
@@ -5,8 +5,8 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x00",
-          "green" : "0x76",
+          "blue" : "0x22",
+          "green" : "0x92",
           "red" : "0xFF"
         }
       },

--- a/Sources/SoundCloud/Models/Page.swift
+++ b/Sources/SoundCloud/Models/Page.swift
@@ -6,6 +6,7 @@
 //
 
 public struct Page<ItemType: Decodable>: Decodable {
+    
     public var items: [ItemType]
     public var nextPageURL: String?
     
@@ -16,6 +17,7 @@ public struct Page<ItemType: Decodable>: Decodable {
 }
 
 extension Page {
+    
     public var hasNextPage: Bool { nextPageURL != nil }
 
     public mutating func update(with next: Page<ItemType>) {
@@ -30,7 +32,7 @@ extension Page {
 }
 
 public extension Page where ItemType == Track {
-    func playlist(id: Int, title: String, user: User) -> Playlist {
+    func playlist(id: URN, title: String, user: User) -> Playlist {
         Playlist(
             id: id,
             user: user,

--- a/Sources/SoundCloud/Models/Playlist.swift
+++ b/Sources/SoundCloud/Models/Playlist.swift
@@ -5,8 +5,9 @@
 //  Created by Ryan Forsyth on 2023-10-03.
 //
 
-public struct Playlist: Decodable, Identifiable, Equatable {
-    public let id: Int
+public struct Playlist: Decodable, Hashable, Identifiable, Equatable {
+    
+    public let id: URN
     public let genre: String
     public let permalink: String
     public let permalinkUrl: String
@@ -29,7 +30,7 @@ public struct Playlist: Decodable, Identifiable, Equatable {
     public var tracks: [Track]? 
     public var nextPageUrl: String?
     public init(
-        id: Int,
+        id: URN,
         genre: String = "",
         permalink: String = "",
         permalinkUrl: String = "https://soundcloud.com",
@@ -75,6 +76,11 @@ public struct Playlist: Decodable, Identifiable, Equatable {
         self.tracks = tracks
         self.nextPageUrl = nextPageUrl
     }
+    
+    private enum CodingKeys: String, CodingKey {
+        case id = "urn"
+        case genre, permalink, permalinkUrl, description, uri, tagList, trackCount, lastModified, license, user, likesCount, sharing, createdAt, tags, kind, title, streamable, artworkUrl, tracksUri, tracks, nextPageUrl
+    }
 }
 
 extension Playlist {
@@ -102,12 +108,12 @@ extension Playlist {
     }
 }
 
-public enum PlaylistType: Int, CaseIterable {
-    case nowPlaying = 1
-    case downloads
-    case likes
-    case recentlyPosted // By people current user follows
-    case relatedTracks
+public enum PlaylistType: String, CaseIterable {
+    case nowPlaying = "nowPlaying"
+    case downloads = "downloads"
+    case likes = "likes"
+    case recentlyPosted = "recentlyPosted" // By people current user follows
+    case relatedTracks = "relatedTracks"
     
     public var title: String {
         switch self {

--- a/Sources/SoundCloud/Models/Test Models.swift
+++ b/Sources/SoundCloud/Models/Test Models.swift
@@ -5,7 +5,7 @@
 //  Created by Ryan Forsyth on 2023-10-03.
 //
 
-public func testUser(_ id: Int = Int.random(in: 0..<1000)) -> User {
+public func testUser(_ id: String = "\(Int.random(in: 0..<1000))") -> User {
     User(
         avatarUrl: "https://i1.sndcdn.com/avatars-0DxRBnyCNCI3zL1X-oeoRyw-large.jpg",
         id: id,
@@ -41,7 +41,7 @@ public func testUser(_ id: Int = Int.random(in: 0..<1000)) -> User {
 
 public func testPlaylist(empty: Bool = false) -> Playlist {
     Playlist (
-        id: Int.random(in: 0..<1000),
+        id: "\(Int.random(in: 0..<1000))",
         genre: "",
         permalink: "",
         permalinkUrl: "https://google.com",
@@ -67,7 +67,7 @@ public func testPlaylist(empty: Bool = false) -> Playlist {
 
 public func testTrack(isLiked: Bool = false) -> Track {
     Track(
-        id: Int.random(in: 0..<1000),
+        id: "\(Int.random(in: 0..<1000))",
         createdAt: "2023/08/08 08:24:13 +0000",
         duration: 3678067,
         commentCount: 0,
@@ -95,13 +95,35 @@ public func testTrack(isLiked: Bool = false) -> Track {
     )
 }
 
-public var testDefaultLoadedPlaylists: [Int : Playlist] {
-    var loadedPlaylists = [Int : Playlist]()
+public var testDefaultLoadedPlaylists: [URN : Playlist] {
+    var loadedPlaylists = [URN : Playlist]()
     let user = testUser()
-    loadedPlaylists[PlaylistType.nowPlaying.rawValue] = Playlist(id: PlaylistType.nowPlaying.rawValue, user: user, title: PlaylistType.nowPlaying.title, tracks: [])
-    loadedPlaylists[PlaylistType.downloads.rawValue] = Playlist(id: PlaylistType.downloads.rawValue, user: user, title: PlaylistType.downloads.title, tracks: [])
-    loadedPlaylists[PlaylistType.likes.rawValue] = Playlist(id: PlaylistType.likes.rawValue, permalinkUrl: user.permalinkUrl + "/likes", user: user, title: PlaylistType.likes.title, tracks: [])
-    loadedPlaylists[PlaylistType.recentlyPosted.rawValue] = Playlist(id: PlaylistType.recentlyPosted.rawValue, permalinkUrl: user.permalinkUrl + "/following", user: user, title: PlaylistType.recentlyPosted.title, tracks: [])
+    loadedPlaylists[PlaylistType.nowPlaying.rawValue] = Playlist(
+        id: PlaylistType.nowPlaying.rawValue,
+        user: user,
+        title: PlaylistType.nowPlaying.title,
+        tracks: []
+    )
+    loadedPlaylists[PlaylistType.downloads.rawValue] = Playlist(
+        id: PlaylistType.downloads.rawValue,
+        user: user,
+        title: PlaylistType.downloads.title,
+        tracks: []
+    )
+    loadedPlaylists[PlaylistType.likes.rawValue] = Playlist(
+        id: PlaylistType.likes.rawValue,
+        permalinkUrl: user.permalinkUrl + "/likes",
+        user: user,
+        title: PlaylistType.likes.title,
+        tracks: []
+    )
+    loadedPlaylists[PlaylistType.recentlyPosted.rawValue] = Playlist(
+        id: PlaylistType.recentlyPosted.rawValue,
+        permalinkUrl: user.permalinkUrl + "/following",
+        user: user,
+        title: PlaylistType.recentlyPosted.title,
+        tracks: []
+    )
     return loadedPlaylists
 }
 

--- a/Sources/SoundCloud/Models/Track.swift
+++ b/Sources/SoundCloud/Models/Track.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public struct Track: Codable, Identifiable {
-    public let id: Int
+    public let id: URN
     public let createdAt: String
     public let duration: Int
     public let commentCount: Int?
@@ -33,7 +33,12 @@ public struct Track: Codable, Identifiable {
     public let favoritingsCount: Int?
     public let repostsCount: Int?
     public let access: String // playable / preview / blocked
-    
+
+    private enum CodingKeys: String, CodingKey {
+        case id = "urn"
+        case createdAt, duration, commentCount, sharing, tagList, streamable, genre, title, description, license, uri, user, permalinkUrl, artworkUrl, streamUrl, downloadUrl, waveformUrl, availableCountryCodes, userFavorite, userPlaybackCount, playbackCount, favoritingsCount, repostsCount, access
+    }
+
     public var localFileUrl: String? = nil // For downloaded tracks
 }
 

--- a/Sources/SoundCloud/Models/User.swift
+++ b/Sources/SoundCloud/Models/User.swift
@@ -7,7 +7,7 @@
 
 public struct User: Codable, Equatable {
     public let avatarUrl: String
-    public let id: Int
+    public let id: URN
     public let permalinkUrl: String
     public let uri: String
     public let username: String
@@ -30,7 +30,7 @@ public struct User: Codable, Equatable {
     
     public init(
         avatarUrl: String = "",
-        id: Int,
+        id: URN,
         permalinkUrl: String = "",
         uri: String = "",
         username: String = "",
@@ -72,6 +72,11 @@ public struct User: Codable, Equatable {
         self.likesCount = likesCount
         self.playlistCount = playlistCount
         self.subscriptions = subscriptions
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id = "urn"
+        case avatarUrl, permalinkUrl, uri, username, createdAt, firstName, lastName, fullName, city, country, description, trackCount, repostsCount, followersCount, followingsCount, commentsCount, online, likesCount, playlistCount, subscriptions
     }
 }
 

--- a/Sources/SoundCloud/Request.swift
+++ b/Sources/SoundCloud/Request.swift
@@ -29,7 +29,7 @@ extension SoundCloud {
                 _ redirectURI: String
             )
             
-            case myUser
+            case currentUser
             case myLikedTracks(_ limit: Int)
             case myFollowingsRecentlyPosted(_ limit: Int)
             case myLikedPlaylists
@@ -75,8 +75,8 @@ extension SoundCloud {
             .init(api: .refreshAccessToken(refreshToken, clientId, clientSecret, redirectURI))
         }
         
-        static func myUser() -> Request<User> {
-            .init(api: .myUser)
+        static func currentUser() -> Request<User> {
+            .init(api: .currentUser)
         }
         
         static func myLikedTracks(_ limit: Int = 100) -> Request<Page<Track>> {
@@ -213,7 +213,7 @@ extension SoundCloud.Request {
         case .accessToken: "oauth/token"
         case .refreshAccessToken: "oauth/token"
         
-        case .myUser: "me"
+        case .currentUser: "me"
         case .myLikedTracks: "me/likes/tracks"
         case .myFollowingsRecentlyPosted: "me/followings/tracks"
         case .myLikedPlaylists: "me/likes/playlists"

--- a/Sources/SoundCloud/Request.swift
+++ b/Sources/SoundCloud/Request.swift
@@ -34,19 +34,19 @@ extension SoundCloud {
             case myFollowingsRecentlyPosted(_ limit: Int)
             case myLikedPlaylists
             case myPlaylists
-            case tracksForPlaylist(_ id: Int, _ limit: Int)
-            case tracksForUser(_ id: Int, _ limit: Int)
-            case likedTracksForUser(_ id: Int, _ limit: Int)
-            case relatedTracks(_ tracksRelatedToId: Int, _ limit: Int)
-            case streamInfoForTrack(_ id: Int)
+            case tracksForPlaylist(_ id: URN, _ limit: Int)
+            case tracksForUser(_ id: URN, _ limit: Int)
+            case likedTracksForUser(_ id: URN, _ limit: Int)
+            case relatedTracks(_ tracksRelatedToId: URN, _ limit: Int)
+            case streamInfoForTrack(_ id: URN)
             case usersImFollowing
             
-            case likeTrack(_ id: Int)
-            case unlikeTrack(_ id: Int)
-            case likePlaylist(_ id: Int)
-            case unlikePlaylist(_ id: Int)
-            case followUser(_ id: Int)
-            case unfollowUser(_ id: Int)
+            case likeTrack(_ id: URN)
+            case unlikeTrack(_ id: URN)
+            case likePlaylist(_ id: URN)
+            case unlikePlaylist(_ id: URN)
+            case followUser(_ id: URN)
+            case unfollowUser(_ id: URN)
             
             case searchTracks(_ query: String, _ limit: Int)
             case searchPlaylists(_ query: String, _ limit: Int)
@@ -94,23 +94,23 @@ extension SoundCloud {
             .init(api: .myPlaylists)
         }
         
-        static func tracksForPlaylist(_ id: Int, _ limit: Int = 1000) -> Request<Page<Track>> {
+        static func tracksForPlaylist(_ id: URN, _ limit: Int = 1000) -> Request<Page<Track>> {
             .init(api: .tracksForPlaylist(id, limit))
         }
         
-        static func tracksForUser(_ id: Int, _ limit: Int = 20) -> Request<Page<Track>> {
+        static func tracksForUser(_ id: URN, _ limit: Int = 20) -> Request<Page<Track>> {
             .init(api: .tracksForUser(id, limit))
         }
         
-        static func likedTracksForUser(_ id: Int, _ limit: Int = 20) -> Request<Page<Track>> {
+        static func likedTracksForUser(_ id: URN, _ limit: Int = 20) -> Request<Page<Track>> {
             .init(api: .likedTracksForUser(id, limit))
         }
         
-        static func relatedTracks(_ tracksRelatedToId: Int, _ limit: Int = 20) -> Request<Page<Track>> {
+        static func relatedTracks(_ tracksRelatedToId: URN, _ limit: Int = 20) -> Request<Page<Track>> {
             .init(api: .relatedTracks(tracksRelatedToId, limit))
         }
 
-        static func streamInfoForTrack(_ id: Int) -> Request<StreamInfo> {
+        static func streamInfoForTrack(_ id: URN) -> Request<StreamInfo> {
             .init(api: .streamInfoForTrack(id))
         }
         
@@ -118,27 +118,27 @@ extension SoundCloud {
             .init(api: .usersImFollowing)
         }
         
-        static func likeTrack(_ id: Int) -> Request<Status> {
+        static func likeTrack(_ id: URN) -> Request<Status> {
             .init(api: .likeTrack(id))
         }
         
-        static func unlikeTrack(_ id: Int) -> Request<Status> {
+        static func unlikeTrack(_ id: URN) -> Request<Status> {
             .init(api: .unlikeTrack(id))
         }
         
-        static func likePlaylist(_ id: Int) -> Request<Status> {
+        static func likePlaylist(_ id: URN) -> Request<Status> {
             .init(api: .likePlaylist(id))
         }
         
-        static func unlikePlaylist(_ id: Int) -> Request<Status> {
+        static func unlikePlaylist(_ id: URN) -> Request<Status> {
             .init(api: .unlikePlaylist(id))
         }
         
-        static func followUser(_ id: Int) -> Request<User> {
+        static func followUser(_ id: URN) -> Request<User> {
             .init(api: .followUser(id))
         }
 
-        static func unfollowUser(_ id: Int) -> Request<Status> {
+        static func unfollowUser(_ id: URN) -> Request<Status> {
             .init(api: .unfollowUser(id))
         }
         

--- a/Sources/SoundCloud/Request.swift
+++ b/Sources/SoundCloud/Request.swift
@@ -48,6 +48,7 @@ extension SoundCloud {
             case followUser(_ id: URN)
             case unfollowUser(_ id: URN)
             
+            case resolve(_ url: String)
             case searchTracks(_ query: String, _ limit: Int)
             case searchPlaylists(_ query: String, _ limit: Int)
             case searchUsers(_ query: String, _ limit: Int)
@@ -141,7 +142,7 @@ extension SoundCloud {
         static func unfollowUser(_ id: URN) -> Request<Status> {
             .init(api: .unfollowUser(id))
         }
-        
+                
         static func searchTracks(_ query: String, _ limit: Int) -> Request<Page<Track>> {
             .init(api: .searchTracks(query, limit))
         }
@@ -156,6 +157,10 @@ extension SoundCloud {
 
         static func getNextPage<ItemType: Decodable>(_ href: String) -> Request<Page<ItemType>> {
             .init(api: .nextPage(href))
+        }
+        
+        static func resolve<ItemType: Decodable>(_ url: String) -> Request<ItemType> {
+            .init(api: .resolve(url))
         }
     }
 }
@@ -226,6 +231,7 @@ extension SoundCloud.Request {
         case .searchTracks: "tracks"
         case .searchPlaylists: "playlists"
         case .searchUsers: "users"
+        case .resolve: "resolve"
             
         case .nextPage(let href): href
         }
@@ -294,8 +300,12 @@ extension SoundCloud.Request {
             "limit" : "\(limit)",
             "linked_partitioning" : "true"
         ]
+        
+        case let .resolve(url): [
+            "url" : url
+        ]
             
-        default: 
+        default:
             nil
         }
     }
@@ -343,7 +353,7 @@ extension SoundCloud.Request {
         case .followUser:
             "PUT"
         
-        default: 
+        default:
             "GET"
         }
     }
@@ -353,7 +363,6 @@ extension SoundCloud.Request {
 extension SoundCloud.Request {
     
     var shouldUseAuthHeader: Bool {
-        
         switch api {
         case .accessToken, .refreshAccessToken: false
         default: true
@@ -361,10 +370,9 @@ extension SoundCloud.Request {
     }
         
     var isNextPageRequest: Bool {
-        
         switch api {
-            case .nextPage: true
-            default: false
+        case .nextPage: true
+        default: false
         }
     }
 }

--- a/Sources/SoundCloud/SoundCloud.swift
+++ b/Sources/SoundCloud/SoundCloud.swift
@@ -7,7 +7,7 @@
 
 import AuthenticationServices
 import Combine
-import Consolable
+import OSLog
 
 /// Uniform Resource Name
 ///
@@ -24,7 +24,6 @@ public typealias URN = String
 ///
 /// - Important: OAuth tokens are stored in the `Keychain` by default.
 /// - SeeAlso: Visit the [SoundCloud API Explorer](https://developers.soundcloud.com/docs/api/explorer/open-api#/) for more information.
-@Consolable("🌩️")
 public final class SoundCloud {
             
     private let config: Config
@@ -87,7 +86,7 @@ public extension SoundCloud {
             throw Error.userNotAuthorized
         }
         if savedAuthTokens.isExpired {
-            log("⏰ Access token expired at: \(savedAuthTokens.expiryDate!)")
+            Logger.auth.info("⏰ Access token expired at: \(savedAuthTokens.expiryDate!)")
             try await refreshAuthTokens()
         }
         let validAuthTokens = try! tokenDAO.get()
@@ -421,10 +420,10 @@ private extension SoundCloud {
     // MARK: - Debug logging 📝
     func logCurrentAuthToken() {
         let token = try? tokenDAO.get().accessToken
-        log("💾 Current access token: \(token ?? "None")")
+        Logger.auth.info("💾 Current access token: \(token ?? "None")")
     }
     
     func logNewAuthToken(_ token: String) {
-        log("🌟 Received new access token: \(token)")
+        Logger.auth.info("🌟 Received new access token: \(token)")
     }
 }

--- a/Sources/SoundCloud/SoundCloud.swift
+++ b/Sources/SoundCloud/SoundCloud.swift
@@ -178,6 +178,37 @@ public extension SoundCloud {
     }
 
     // MARK: - Miscellaneous ✨
+    
+    /// Resolve a SoundCloud web URL to its canonical API resource.
+    ///
+    /// Use this to turn a user-facing SoundCloud URL (e.g., `https://soundcloud.com/...` or
+    /// `https://on.soundcloud.com/...`) into a strongly-typed API model such as `Track`,
+    /// `Playlist`, or `User`.
+    ///
+    /// The generic `ItemType` you choose must match the resource type the URL resolves to.
+    ///
+    /// - Parameter url: A full SoundCloud URL to resolve.
+    /// - Returns: The decoded resource of the specified type.
+    /// - Throws: The same errors as other API calls, including authorization, network, and decoding failures.
+    ///
+    /// ### Examples
+    /// ```swift
+    /// // Track
+    /// let track: Track = try await sc.resolve("https://soundcloud.com/user/track-permalink")
+    ///
+    /// // Playlist
+    /// let playlist: Playlist = try await sc.resolve("https://soundcloud.com/user/sets/my-set")
+    ///
+    /// // User
+    /// let user: User = try await sc.resolve("https://soundcloud.com/username")
+    ///
+    /// // Short links are also supported
+    /// let shortTrack: Track = try await sc.resolve("https://on.soundcloud.com/abc123")
+    /// ```
+    func resolve<ItemType: Decodable>(_ url: String) async throws -> ItemType {
+        try await get(.resolve(url))
+    }
+    
     func pageOfItems<ItemType>(for href: String) async throws -> Page<ItemType> {
         try await get(.getNextPage(href))
     }

--- a/Sources/SoundCloud/SoundCloud.swift
+++ b/Sources/SoundCloud/SoundCloud.swift
@@ -7,8 +7,12 @@
 
 import AuthenticationServices
 import Combine
-import CryptoKit
-import OSLog
+import Consolable
+
+/// Uniform Resource Name
+///
+/// See [SoundCloud developers blog article](https://developers.soundcloud.com/blog/urn-num-to-string)
+public typealias URN = String
 
 /// Handles the logic for making authenticated requests to the SoundCloud API.
 ///
@@ -20,6 +24,7 @@ import OSLog
 ///
 /// - Important: OAuth tokens are stored in the `Keychain` by default.
 /// - SeeAlso: Visit the [SoundCloud API Explorer](https://developers.soundcloud.com/docs/api/explorer/open-api#/) for more information.
+@Consolable("🌩️")
 public final class SoundCloud {
             
     private let config: Config
@@ -83,7 +88,7 @@ public extension SoundCloud {
             throw Error.userNotAuthorized
         }
         if savedAuthTokens.isExpired {
-            logAuthTokenExpired(savedAuthTokens.expiryDate!)
+            log("⏰ Access token expired at: \(savedAuthTokens.expiryDate!)")
             try await refreshAuthTokens()
         }
         let validAuthTokens = try! tokenDAO.get()
@@ -116,20 +121,20 @@ public extension SoundCloud {
     }
 
     // MARK: - Tracks 💿
-    func getTracksForPlaylist(_ id: Int) async throws -> Page<Track> {
+    func getTracksForPlaylist(_ id: URN) async throws -> Page<Track> {
         try await get(.tracksForPlaylist(id))
     }
     
-    func getTracksForUser(_ id: Int, _ limit: Int = 20) async throws -> Page<Track> {
+    func getTracksForUser(_ id: URN, _ limit: Int = 20) async throws -> Page<Track> {
         try await get(.tracksForUser(id, limit))
     }
     
-    func getLikedTracksForUser(_ id: Int, _ limit: Int = 20) async throws -> Page<Track> {
+    func getLikedTracksForUser(_ id: URN, _ limit: Int = 20) async throws -> Page<Track> {
         try await get(.likedTracksForUser(id, limit))
     }
     
-    func getRelatedTracks(_ id: Int, _ limit: Int = 20) async throws -> Page<Track> {
-        return try await get(.relatedTracks(id, limit))
+    func getRelatedTracks(_ id: URN, _ limit: Int = 20) async throws -> Page<Track> {
+        try await get(.relatedTracks(id, limit))
     }
 
     // MARK: - Search 🕵️
@@ -177,7 +182,7 @@ public extension SoundCloud {
         try await get(.getNextPage(href))
     }
     
-    func getStreamInfoForTrack(with id: Int) async throws -> StreamInfo {
+    func getStreamInfoForTrack(with id: URN) async throws -> StreamInfo {
         try await get(.streamInfoForTrack(id))
     }
     
@@ -277,14 +282,10 @@ private extension SoundCloud {
     // MARK: - Debug logging 📝
     func logCurrentAuthToken() {
         let token = try? tokenDAO.get().accessToken
-        Logger.auth.info("💾 Current access token: \(token ?? "None", privacy: .private)")
+        log("💾 Current access token: \(token ?? "None")")
     }
     
     func logNewAuthToken(_ token: String) {
-        Logger.auth.info("🌟 Received new access token: \(token, privacy: .private)")
-    }
-    
-    func logAuthTokenExpired(_ date: Date) {
-        Logger.auth.warning("⏰ Access token expired at: \(date)")
+        log("🌟 Received new access token: \(token)")
     }
 }

--- a/Tests/SoundCloudTests/SoundCloudTests.swift
+++ b/Tests/SoundCloudTests/SoundCloudTests.swift
@@ -1,4 +1,0 @@
-import XCTest
-@testable import SoundCloud
-
-final class SoundCloudTests: XCTestCase { }


### PR DESCRIPTION
## Summary
This PR prepares the 2.0.0 release in response to SoundCloud’s upstream change from numeric IDs to string URNs. It updates models/APIs accordingly, adds the /resolve helper, refreshes docs, and polishes naming to be more Swift-idiomatic.

> [!TIP]
See [SoundCloud API release 2025-04-23](https://github.com/soundcloud/api/releases/tag/2025-04-23)

## Highlights
- Breaking: Migrate all resource identifiers from Int → String URNs (affects models & decoding). 
- #13 
- New `/resolve` endpoint support to turn public URLs/permalinks into canonical resources. 
- Shoutout @markst for #11
- API polish: Swift-ier naming tweaks for clarity and consistency.
- Docs: Updated README (Migration Notes), expanded DocC for the public API.
- Changelog: Added entry for 2.0.0.

## Details
- Update model id properties to URN String across common entities (e.g., tracks, users, playlists).
- Adjust decoding/serialization and convenience methods to operate on URNs.
- Introduce a resolve(...) convenience API to fetch canonical entities from URLs/permalinks.
- Documentation:
   - README: banner + migration guidance; links to upstream announcement.
   - DocC: refreshed symbols and overviews for public surface.

### Why major version? 🤔
**Responses now contain URNs**; code expecting Int IDs can misparse or persist the wrong type. SemVer bump prevents silent breakage.

## Migration notes for integrators
- Change any id: Int to id: String (URN).
- Remove casts between String and Int for IDs.
- Update persistence (Core Data / DB schemas, caches, dictionary keys) to String.
- When starting from a public URL, prefer the new /resolve helper.

## Testing / Validation
- Authenticate and fetch likedTracks() (IDs should be URNs).
- Use /resolve with a track/user/playlist URL and verify canonical entity.
- Smoke test iOS/watchOS/macOS SPM integration builds.
- Ensure existing example code compiles on 2.0.0 and returns data with URN IDs.

## Release checklist
- Update README + DocC
- Changelog for 2.0.0
- Tag v2.0.0